### PR TITLE
Standardize press release headers

### DIFF
--- a/frontend/content/press/releases/fascist-coup-attempt.md
+++ b/frontend/content/press/releases/fascist-coup-attempt.md
@@ -8,7 +8,11 @@ description:
 
 {{< header />}}
 
-# AWU statement on fascist coup attempt
+**FOR IMMEDIATE RELEASE**
+
+_January 7, 2021 at 2pm ET_
+
+_Press contact: press@alphabetworkersunion.org_
 
 Yesterday, a mob of fascists, urged on by the sitting president of the United States, stormed the Capitol in Washington, D.C. in an attempt to prevent the certification of the results of the presidential election. Donald Trump then celebrated the insurrectionists in a video posted on social media, including on his YouTube channel, where he told armed fascists, “We love you, you’re very special.”
 

--- a/frontend/content/press/releases/retaliation-against-margaret-mitchell.en.md
+++ b/frontend/content/press/releases/retaliation-against-margaret-mitchell.en.md
@@ -8,9 +8,11 @@ description:
 
 {{< header />}}
 
-# AWU statement on retaliation against Margaret Mitchell
+**FOR IMMEDIATE RELEASE**
 
-For immediate release
+_January 20, 2021 at 2pm ET_
+
+_Press contact: press@alphabetworkersunion.org_
 
 The Alphabet Workers Union (AWU) is concerned by the suspension of the corporate access of Margaret Mitchell, AWU member and lead of the Ethical AI team. This suspension comes on the heels of [Google’s firing of former co-lead Timnit Gebru](https://www.nytimes.com/2020/12/03/technology/google-researcher-timnit-gebru.html); together these are an attack on the people who are trying to make Google’s technology more ethical.
 

--- a/frontend/content/press/releases/workers-fight-google-contractors-attempt-to-bar-wage-discussion.en.md
+++ b/frontend/content/press/releases/workers-fight-google-contractors-attempt-to-bar-wage-discussion.en.md
@@ -10,7 +10,7 @@ layout: textheavy
 
 **FOR IMMEDIATE RELEASE**
 
-February 4, 2021 at 3pm ET
+_February 4, 2021 at 3pm ET_
 
 _Press contact: press@alphabetworkersunion.org_
 


### PR DESCRIPTION
Using first release (going public) as the standard.