### PR TITLE
Fix for CAD currency

### DIFF
--- a/signup-worker/src/global.d.ts
+++ b/signup-worker/src/global.d.ts
@@ -2,6 +2,7 @@
 declare const STRIPE_KEY: string;
 declare const DUES_PRODUCT_ID: string;
 declare const DUES_SIGNUP_PRICE_ID: string;
+declare const INITIATION_FEE_PRODUCT_ID: string;
 declare const CARD_FEE_PRODUCT_ID: string;
 
 declare const PLAID_CLIENT_ID: string;

--- a/signup-worker/src/handler.ts
+++ b/signup-worker/src/handler.ts
@@ -124,9 +124,10 @@ export async function handleRequest(request: Request): Promise<Response> {
       }
       throw error;
     }
+    const currency = fields.get('currency') as string;
 
     const subscriptionItems = getSubscriptionItems(
-      fields.get('currency') as string,
+      currency,
       Number(fields.get('total-compensation') as string),
       paymentMethod,
     );
@@ -149,7 +150,11 @@ export async function handleRequest(request: Request): Promise<Response> {
       stripeClient
         .createInvoiceItem({
           customer: customer.id,
-          price: DUES_SIGNUP_PRICE_ID,
+          price_data: {
+            currency: currency,
+            product: INITIATION_FEE_PRODUCT_ID,
+            unit_amount: 500,
+          },
         })
         .then(() =>
           stripeClient.createInvoice({


### PR DESCRIPTION
The issue is we're hardcoding a USD price on the initiation fee, the card fee and dues charge themselves refer to a product id instead (so the currency Just Works)