### PR TITLE
Update "site code" field to be required

### DIFF
--- a/frontend/src/element/signup.ts
+++ b/frontend/src/element/signup.ts
@@ -839,7 +839,7 @@ export class Signup extends LitElement {
           <span class="hint"
             >So we can connect you with your local chapters. Site code is a
             country code followed by a location code (for example,
-            "US-MTV").</span
+            "US-MTV"). If you do not work in an office, please enter "REMOTE".</span
           >
           <input
             name="site-code"

--- a/signup-worker/src/fields.ts
+++ b/signup-worker/src/fields.ts
@@ -16,6 +16,7 @@ const REQUIRED_METADATA = [
   'have-reports',
   'total-compensation',
   'sms-consent',
+  'site-code',
 ];
 
 export const REQUIRED_FIELDS = REQUIRED_METADATA.concat([
@@ -24,7 +25,6 @@ export const REQUIRED_FIELDS = REQUIRED_METADATA.concat([
 ]);
 
 export const FTE_REQUIRED_FIELDS = REQUIRED_FIELDS.concat([
-  'site-code',
   'org',
   'team',
 ]);
@@ -37,7 +37,6 @@ const OPTIONAL_METADATA = [
   'product-area',
   'work-email',
   'birthday',
-  'site-code',
   'org',
   'team',
 ];


### PR DESCRIPTION
Currently this is an optional field for non FTEs filling out the sign-up form. Having it be empty causes issues for membership imports. This change aims to update the field to required, as well as update the relevant hint text to provide information about what to do if you do not work in an office.