### PR TITLE
Change Dues wording

### DIFF
--- a/frontend/src/element/signup.ts
+++ b/frontend/src/element/signup.ts
@@ -991,9 +991,9 @@ export class Signup extends LitElement {
           </div>
         </div>
         <label>
-          <span class="title">Monthly dues</span>
+          <span class="title">Calculated dues</span>
           <span class="hint"
-            >Dues are 1% of your TC, plus processing fee if you opt to pay with
+            >Annual dues are 1% of your TC, plus processing fee if you opt to pay with
             a card. This is billed monthly, and is pooled and democratically
             controlled by you and your fellow members.</span
           >


### PR DESCRIPTION
The language here currently says "monthly dues" then immediately says "Dues are 1% of TC". After you type in a number, this becomes clearer, but change the titles so that it's more clear before you type in a number.

This has come up several times in the past couple days, and feels urgent; I think this becomes completely clear once you type a number in, but is confusing until then.