### PR TITLE
Use local month rather than UTC Month to set date

### DIFF
--- a/signup-worker/src/handler.ts
+++ b/signup-worker/src/handler.ts
@@ -20,7 +20,7 @@ const POTENTIAL_ERROR_TOTAL_COMP_THRESHOLD = 8500;
 function getBillingAnchor(): Date {
   const now = new Date();
   now.setUTCDate(1);
-  now.setUTCMonth(now.getUTCMonth() + 1);
+  now.setUTCMonth(now.getMonth() + 1);
   // Setting 8 hours means that we'll get the right day on the invoice if
   // the Stripe account is in UTC (a likely default), Eastern (local 1400),
   // or Pacific time


### PR DESCRIPTION
We are attempting to find "The first of the month following this one" in the _user_'s timezone. By setting the timestamp 8 hours into the day, we will always make sure that the subscription refresh time is in the future, even if someone signs up at 11:59pm in Mountain View on the last day of the month.