### PR TITLE
Adjusts sign up form name entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/frontend/src/element/signup.ts
+++ b/frontend/src/element/signup.ts
@@ -562,14 +562,14 @@ export class Signup extends LitElement {
         <label class="full-width">
           <span class="title">Name${this.optionalLabel('preferred-name')}</span>
           <span class="hint"
-            >Enter the name you want union members to use when communicating
-            with you</span
+            >Enter the full name you want union members to use when
+            communicating with you</span
           >
           <input
             name="preferred-name"
             aria-label="Name"
             ?required=${this.isFieldRequired('preferred-name')}
-            autocomplete="name"
+            autocomplete="off"
           />
         </label>
         <label>


### PR DESCRIPTION
Previously facing issue where card signs would sometimes not include the full name. This was potentially caused by two problems:

1) Not being clear enough that we require the full name and not just the first name.

2) Autocomplete requiring two name fields for first and last name, and only filling in the first name when autocompleting for out field that should request for the full name.

To alleviate this, the change hopes to make the message more clear to the signer and turns off autocomplete for the name field.