### PR TITLE
update NYC in events page

### DIFF
--- a/frontend/content/campaigns/local-launch.en.md
+++ b/frontend/content/campaigns/local-launch.en.md
@@ -39,7 +39,6 @@ On **Thursday, 4 May** our chapters will host member socials at Alphabet sites a
 | Seattle          | TBD                                          | |
 | Bay Area         | TBD: Mountain View                           | |
 | Austin, TX       | Moontower Cider, 1916 Tillery St.            | |
-| NYC              | TBD                                          | |
 | Cambridge        | Promenade in CAM office                      | [go.awu.fyi/cam-launch](https://go.awu.fyi/cam-launch) |
 | So Cal           | TBD                                          | |
 | Triangle, NC     | TBD                                          | |

--- a/frontend/content/campaigns/local-launch.en.md
+++ b/frontend/content/campaigns/local-launch.en.md
@@ -1,0 +1,48 @@
+---
+title: 'CWA Local 9009 Launch'
+linktitle: 'CWA Local 9009 Launch'
+date: 2023-04-22T10:00:00-05:00
+weight: 3
+layout: textheavy
+---
+
+{{< header />}}
+
+Self-link: [go.awu.fyi/local-launch](https://go.awu.fyi/local-launch)
+
+### Our New Local
+
+Alphabet Workers Union-CWA is becoming its own union local: CWA Local 9009. After incubating our union within CWA Local 1400, we will move our virtual headquarters from New Hampshire to Mountain View, CA. A local union—or "local"—is a branch of a larger national or international trade union. Locals are dedicated to organizing workers in a particular geographic area or at a particular company. In the case of CWA Local 9009, we were chartered by the Communications Workers of America board to organize workers with the following jurisdiction:
+
+*Employees of Alphabet and its subsidiaries, as well as, employees at vendor companies in bargaining units performing work for Alphabet and its subsidiaries that is similar to the aforementioned employees, throughout the United States of America, Canada, and other jurisdictions as may be assigned by the Executive Board of the Union, except where the principal organizing effort for any such employees is performed by another CWA Local.*
+
+As part of this transition, our union will become its own independent legal and tax entity, move to CWA District 9, and commit to further growing worker power at Alphabet, its subsidiaries, and their subcontractors.
+
+### Launch Call
+
+On **Monday, 1 May** (May Day) we will have an all-member meeting at **4:30PM PT/7:30PM ET** to commemorate the founding of our new local: CWA Local 9009. We will learn a bit more about what it means to be our own local, be welcomed by CWA District 9 President Frank Arce, and hear updates about our latest campaigns.
+
+Register at [go.awu.fyi/member-meeting](https://go.awu.fyi/member-meeting)
+
+### Launch Socials
+
+On **Thursday, 4 May** our chapters will host member socials at Alphabet sites across the US and Canada:
+
+<center>
+
+| Location/Chapter | Location Venue & Address                     | Registration      |
+| ---------------- | -------------------------------------------- | ----------------- |
+| Chicago          | Time Out Market Chicago, 916 W Fulton Market | On-Corp Invite    |
+| Waterloo, Canada | TBD                                          | |
+| Montreal, Canada | TBD                                          | |
+| Pittsburgh, PA   | TBD                                          | |
+| Seattle          | TBD                                          | |
+| Bay Area         | TBD: Mountain View                           | |
+| Austin, TX       | Moontower Cider, 1916 Tillery St.            | |
+| NYC              | TBD                                          | |
+| Cambridge        | Promenade in CAM office                      | [go.awu.fyi/cam-launch](https://go.awu.fyi/cam-launch) |
+| So Cal           | TBD                                          | |
+| Triangle, NC     | TBD                                          | |
+| New York City    | TBD                                          | [go.awu.fyi/nyc-launch](https://go.awu.fyi/nyc-launch) |
+
+</center>

--- a/frontend/content/campaigns/local-launch.en.md
+++ b/frontend/content/campaigns/local-launch.en.md
@@ -1,6 +1,6 @@
 ---
-title: 'CWA Local 9009 Launch'
-linktitle: 'CWA Local 9009 Launch'
+title: 'CWA Local 9009'
+linktitle: 'CWA Local 9009'
 date: 2023-04-22T10:00:00-05:00
 weight: 3
 layout: textheavy


### PR DESCRIPTION
- Add local launch landing page
- Shorten link title
- Remove duplicate NYC row
