### PR TITLE
Join form calculator icon

### DIFF
--- a/join-form-js/src/signup.scss
+++ b/join-form-js/src/signup.scss
@@ -1,5 +1,11 @@
+$brand: #ed1c24;
+$brand-dark: #c60020;
+$gray-70: #6c6865;
+$gray-80: #525153;
+$black: #000e26;
+
 h2 {
-  color: #ed1c24;
+  color: $brand;
   font-size: 1.4em;
   font-weight: 700;
   padding: 0 10px;
@@ -34,7 +40,7 @@ form {
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   column-gap: 32px;
   row-gap: 16px;
-  color: #525153;
+  color: $gray-80;
 
   &.disabled {
     opacity: 0.6;
@@ -66,7 +72,7 @@ label,
   margin-bottom: 4px;
   padding: 0 10px;
   font-weight: 500;
-  color: #6c6865;
+  color: $gray-70;
 
   &.or {
     text-align: center;
@@ -185,7 +191,7 @@ label,
 }
 
 .dues-card-multiplier {
-  color: #ed1c24;
+  color: $brand;
 }
 
 .card-container,
@@ -193,19 +199,19 @@ input,
 select,
 button {
   font-size: 24px;
-  border: solid 1px #525153;
+  border: solid 1px $gray-80;
   border-radius: 10px;
   padding: 0 8px;
   background: white;
   line-height: 46px; // Height minus border
   height: 48px;
   box-sizing: border-box;
-  color: #525153;
+  color: $gray-80;
 }
 
 button {
-  color: #ed1c24;
-  border: solid 2px #ed1c24;
+  color: $brand;
+  border: solid 2px $brand;
   line-height: 44px; // Height minus border
   font-weight: 600;
   padding: 0 16px;
@@ -213,8 +219,8 @@ button {
 }
 
 button[disabled] {
-  border-color: #525153;
-  color: #525153;
+  border-color: $gray-80;
+  color: $gray-80;
   opacity: 0.7;
   cursor: default;
 }
@@ -252,7 +258,7 @@ select {
   content: '';
   width: 10px;
   height: 6px;
-  background-color: #000e26;
+  background-color: $black;
   clip-path: polygon(100% 0%, 0 0%, 50% 100%);
   position: absolute;
   top: 22px;
@@ -284,13 +290,13 @@ select {
 
 button.primary,
 .payment-method-toggle button.selected {
-  background: #ed1c24;
+  background: $brand;
   color: white;
   cursor: auto;
 }
 
 button.primary:hover {
-  background-color: #c60020;
+  background-color: $brand-dark;
   cursor: pointer;
 }
 

--- a/join-form-js/src/signup.scss
+++ b/join-form-js/src/signup.scss
@@ -211,12 +211,16 @@ button {
 
 button {
   color: $brand;
-  fill: $brand;
-  border: solid 2px $brand;
+  fill: currentcolor;
+  border: solid 2px currentcolor;
   line-height: 44px; // Height minus border
   font-weight: 600;
   padding: 0 16px;
   font-size: 20px;
+
+  &:hover {
+    color: $brand-dark;
+  }
 }
 
 button[disabled] {
@@ -294,6 +298,7 @@ button.primary,
 .payment-method-toggle button.selected {
   background: $brand;
   color: white;
+  border-color: transparent;
   cursor: auto;
 }
 

--- a/join-form-js/src/signup.scss
+++ b/join-form-js/src/signup.scss
@@ -211,6 +211,7 @@ button {
 
 button {
   color: $brand;
+  fill: $brand;
   border: solid 2px $brand;
   line-height: 44px; // Height minus border
   font-weight: 600;
@@ -221,6 +222,7 @@ button {
 button[disabled] {
   border-color: $gray-80;
   color: $gray-80;
+  fill: $gray-80;
   opacity: 0.7;
   cursor: default;
 }

--- a/join-form-js/src/signup.ts
+++ b/join-form-js/src/signup.ts
@@ -6,6 +6,7 @@ import {
   state,
 } from 'lit-element';
 import { query } from 'lit/decorators.js';
+import { choose } from 'lit-html/directives/choose.js';
 import { classMap } from 'lit-html/directives/class-map.js';
 import { loadStripe, StripeCardElement, Token } from '@stripe/stripe-js';
 import { allCountries } from 'country-region-data';
@@ -941,7 +942,36 @@ export class Signup extends LitElement {
               aria-label="Compensation calculator"
               @click=${this.compCalculatorClickHandler}
             >
-              &#x1F5A9;
+              ${choose(this.isCompCalculatorOpen, [
+                [
+                  false,
+                  // https://fonts.gstatic.com/s/i/short-term/release/materialsymbolsoutlined/calculate/wght200grad200/48px.svg
+                  () => html`<svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    height="48"
+                    viewBox="0 -960 960 960"
+                    width="48"
+                  >
+                    <path
+                      d="M324.385-240.461h38.769v-85.154h85.154v-38.77h-85.154v-84.384h-38.769v84.384H240v38.77h84.385v85.154Zm209.307-32.693h184.616v-38.538H533.692v38.538Zm0-104.154h184.616v-38.769H533.692v38.769Zm32.539-163L624.154-599l59.692 58.692L712-568.231l-59.692-58.154L712-686.077l-28.154-28.154-59.692 58.923-57.923-58.923-28.923 28.154L597-626.385l-59.692 58.154 28.923 27.923Zm-314.308-67.077h182.692v-38.769H251.923v38.769ZM215.384-147q-27.782 0-48.083-20.301T147-215.384v-529.232q0-27.782 20.301-48.083T215.384-813h529.232q27.782 0 48.083 20.301T813-744.616v529.232q0 27.782-20.301 48.083T744.616-147H215.384Zm0-43.769h529.232q9.23 0 16.923-7.692 7.692-7.693 7.692-16.923v-529.232q0-9.23-7.692-16.923-7.693-7.692-16.923-7.692H215.384q-9.23 0-16.923 7.692-7.692 7.693-7.692 16.923v529.232q0 9.23 7.692 16.923 7.693 7.692 16.923 7.692Zm-24.615-578.462v578.462-578.462Z"
+                    />
+                  </svg>`,
+                ],
+                [
+                  true,
+                  // https://fonts.gstatic.com/s/i/short-term/release/materialsymbolsoutlined/calculate/wght200grad200fill1/48px.svg
+                  () => html`<svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    height="48"
+                    viewBox="0 -960 960 960"
+                    width="48"
+                  >
+                    <path
+                      d="M324.385-240.461h38.769v-85.154h85.154v-38.77h-85.154v-84.384h-38.769v84.384H240v38.77h84.385v85.154Zm209.307-32.693h184.616v-38.538H533.692v38.538Zm0-104.154h184.616v-38.769H533.692v38.769Zm32.539-163L624.154-599l59.692 58.692L712-568.231l-59.692-58.154L712-686.077l-28.154-28.154-59.692 58.923-57.923-58.923-28.923 28.154L597-626.385l-59.692 58.154 28.923 27.923Zm-314.308-67.077h182.692v-38.769H251.923v38.769ZM215.384-147q-27.782 0-48.083-20.301T147-215.384v-529.232q0-27.782 20.301-48.083T215.384-813h529.232q27.782 0 48.083 20.301T813-744.616v529.232q0 27.782-20.301 48.083T744.616-147H215.384Z"
+                    />
+                  </svg>`,
+                ],
+              ])}
             </button>
             <span class="input-dollar-symbol"></span>
             <input


### PR DESCRIPTION
Replace the join form's unicode calculator glyph (which had poor cross-platform support) with an svg icon, and add hover state color to make it more clear it is a button.

Before:<br><img width="459" src="https://github.com/alphabetworkers/alphabetworkersunion.org/assets/532638/722b5a69-b1ff-4fc8-81b6-aa8d7520146d">

After:<br><img width="460" src="https://github.com/alphabetworkers/alphabetworkersunion.org/assets/532638/711489ff-b6a2-489c-82bf-e2a1776c49bb">

